### PR TITLE
Add verification tokens for attempts

### DIFF
--- a/web/problems/templates/r/attempt.r
+++ b/web/problems/templates/r/attempt.r
@@ -215,8 +215,11 @@
 
   body <- list()
   indices <- c()
-  {% for part, _, _ in parts %}
+  {% for part, _, token in parts %}
   if (check$part()) {
+    {% if problem.verify_attempt_tokens %}
+    check$parts[[check$part.counter]]$token <- '{{ token }}'
+    {% endif %}
     tryCatch({
       {{ part.validation|indent:"      "|safe }}
     },


### PR DESCRIPTION
To je moj poskus za #145. Da ne bi polomil že prenešenih datotek, sem stvari naredil malo bolj postopoma. Če je naloga označena z `verify_attempt_tokens`, potem ima vsak poskus svoj token, ki je vezan na uporabnika in podnalogo.

@jaanos @mrcinv: ali se vama da preveriti, če R in Octave še vedno delata?
