### PR TITLE
Check.clean returns both type and value, closes #149

### DIFF
--- a/web/problems/templates/python/attempt.py
+++ b/web/problems/templates/python/attempt.py
@@ -164,7 +164,6 @@
 
 
 import io, json, os, re, sys, shutil, traceback, urllib.error, urllib.request
-from contextlib import contextmanager
 
 
 {% include 'python/check.py' %}

--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -33,23 +33,25 @@ class Check:
 
     @staticmethod
     def clean(x, digits=6):
-        if type(x) is float:
+        t = type(x)
+        if t is float:
             x = round(x, digits)
             # Since -0.0 differs from 0.0 even after rounding,
             # we change it to 0.0 abusing the fact it behaves as False.
-            return x if x else 0.0
-        elif type(x) is complex:
-            return complex(Check.clean(x.real, digits), Check.clean(x.imag, digits))
-        elif type(x) is list:
-            return list([Check.clean(y, digits) for y in x])
-        elif type(x) is tuple:
-            return tuple([Check.clean(y, digits) for y in x])
-        elif type(x) is dict:
-            return sorted([(Check.clean(k, digits), Check.clean(v, digits)) for (k, v) in x.items()])
-        elif type(x) is set:
-            return sorted([Check.clean(y, digits) for y in x])
+            v = x if x else 0.0
+        elif t is complex:
+            v = complex(Check.clean(x.real, digits), Check.clean(x.imag, digits))
+        elif t is list:
+            v = list([Check.clean(y, digits) for y in x])
+        elif t is tuple:
+            v = tuple([Check.clean(y, digits) for y in x])
+        elif t is dict:
+            v = sorted([(Check.clean(k, digits), Check.clean(v, digits)) for (k, v) in x.items()])
+        elif t is set:
+            v = sorted([Check.clean(y, digits) for y in x])
         else:
-            return x
+            v = x
+        return (t, v)
 
     @staticmethod
     def secret(x, hint=None, clean=None):

--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 class Check:
     @staticmethod
     def has_solution(part):

--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -34,7 +34,7 @@ class Check:
         Check.feedback(message, *args, **kwargs)
 
     @staticmethod
-    def clean(x, digits=6):
+    def clean(x, digits=6, typed=False):
         t = type(x)
         if t is float:
             x = round(x, digits)
@@ -42,18 +42,18 @@ class Check:
             # we change it to 0.0 abusing the fact it behaves as False.
             v = x if x else 0.0
         elif t is complex:
-            v = complex(Check.clean(x.real, digits), Check.clean(x.imag, digits))
+            v = complex(Check.clean(x.real, digits, typed), Check.clean(x.imag, digits, typed))
         elif t is list:
-            v = list([Check.clean(y, digits) for y in x])
+            v = list([Check.clean(y, digits, typed) for y in x])
         elif t is tuple:
-            v = tuple([Check.clean(y, digits) for y in x])
+            v = tuple([Check.clean(y, digits, typed) for y in x])
         elif t is dict:
-            v = sorted([(Check.clean(k, digits), Check.clean(v, digits)) for (k, v) in x.items()])
+            v = sorted([(Check.clean(k, digits, typed), Check.clean(v, digits, typed)) for (k, v) in x.items()])
         elif t is set:
-            v = sorted([Check.clean(y, digits) for y in x])
+            v = sorted([Check.clean(y, digits, typed) for y in x])
         else:
             v = x
-        return (t, v)
+        return (t, v) if typed else v
 
     @staticmethod
     def secret(x, hint=None, clean=None):

--- a/web/problems/templates/python/edit.py
+++ b/web/problems/templates/python/edit.py
@@ -54,7 +54,6 @@ _validate_current_file()
 # =L=I=B=R=A=R=Y=@=
 
 import io, json, os, re, sys, shutil, traceback, urllib.error, urllib.request
-from contextlib import contextmanager
 
 {% include 'python/check.py' %}
 

--- a/web/problems/templates/python/marking.py
+++ b/web/problems/templates/python/marking.py
@@ -163,7 +163,6 @@
 
 
 import io, json, os, re, sys, shutil, traceback, urllib.error, urllib.request
-from contextlib import contextmanager
 
 
 {% include 'python/check.py' %}


### PR DESCRIPTION
Sem naredil popravek za #149. Popravek je samo za Python - `check$equal` za R je že vključeval preverjanje tipov. @mrcinv, ali rabimo popravek tudi za Octave (morda preverjanje dimenzij)?