### PR TITLE
Allow more whitespace when editing and submitting

### DIFF
--- a/web/problems/templates/octave/attempt.m
+++ b/web/problems/templates/octave/attempt.m
@@ -200,7 +200,7 @@ function validation = validate_current_file(src)
 %        return backup_filename
 %
 %
-  file_parts = extract_parts(src);
+  file_parts = extract_solutions(src);
   check_initialize(file_parts);
 
   {% for part, _, _ in parts %}

--- a/web/problems/templates/octave/edit.m
+++ b/web/problems/templates/octave/edit.m
@@ -14,7 +14,9 @@ check_initialize(file_parts);
 #
 # {{ problem.description|indent:"# "|safe }}{% endif %}{% for part in problem.parts.all %}
 # =====================================================================@{{ part.id|stringformat:'06d'}}=
-# {{ part.description|indent:"# "|safe }}
+# {{ part.description|indent:"# "|safe }}{% if part.template %}
+# -----------------------------------------------------------------------------
+# {{ part.template|indent:"# "|safe }}{% endif %}
 # =============================================================================
 {{ part.solution|safe }}
 
@@ -93,15 +95,15 @@ function validation = validate_current_file(src,parts)
     valid  = [valid parts{i}.valid];
     parts{i} = rmfield(rmfield(rmfield(parts{i},'valid'),'feedback'),'part');
   end
-  problem_regex = ['# =+\n',...                      # beginning of header
-      '# (?<title>[^\n]*)\n',...              # title
-      '(?<description>(#( [^\n]*)?\n)*)',...  # description
-      '(?=(# )?# =+@)',];                     # beginning of first part
+  problem_regex = ['# =+\s*\n',...               # beginning of header
+      '\s*# (?<title>[^\n]*)\n',...              # title
+      '(?<description>(\s*#( [^\n]*)?\n)*)',...  # description
+      '(?=\s*(# )?# =+@)',];                     # beginning of first part
   [s, e, te, m, t, nm, sp] = regexp(src,problem_regex,'dotall');
   problem = struct(
     "parts",{parts},
     "title",strtrim(nm.title),
-    "description",regexprep(strtrim(nm.description),'^#','','lineanchors'),
+    "description",regexprep(strtrim(nm.description),'^\s*# ?','','lineanchors'),
     "id", {{ problem.id }},
     "problem_set", {{ problem.problem_set.id }}
   );

--- a/web/problems/templates/octave/edit.m
+++ b/web/problems/templates/octave/edit.m
@@ -20,7 +20,7 @@ check_initialize(file_parts);
 # =============================================================================
 {{ part.solution|safe }}
 
-check_part()
+check_part();
 {{ part.validation|safe }}
 
 {% endfor %}
@@ -38,16 +38,16 @@ check_part()
 # # =============================================================================
 #
 # function p = {% trans "multiply" %}(x, y)
-#     p =  x * y
+#     p =  x * y;
 # endfunction
 #
-# check_part()
+# check_part();
 #
-# check_equal('{% trans "multiply" %}(3, 7)', 21)
-# check_equal('{% trans "multiply" %}(6, 7)', 42)
-# check_equal('{% trans "multiply" %}(10, 10)', 100)
-# check_secret({% trans "multiply" %}(100, 100))
-# check_secret({% trans "multiply" %}(500, 123))
+# check_equal('{% trans "multiply" %}(3, 7)', 21);
+# check_equal('{% trans "multiply" %}(6, 7)', 42);
+# check_equal('{% trans "multiply" %}(10, 10)', 100);
+# check_secret({% trans "multiply" %}(100, 100));
+# check_secret({% trans "multiply" %}(500, 123));
 
 
 # ===========================================================================@=

--- a/web/problems/templates/octave/utils.m
+++ b/web/problems/templates/octave/utils.m
@@ -3,7 +3,7 @@ function parts = extract_parts(src)
     part_regex = [part_regex '(?<description>(#( [^\n]*)?\n)+)']; # description
     part_regex = [part_regex '# =+\n'];           # end of header
     part_regex = [part_regex '(?<solution>.*?)']; # solution
-    part_regex = [part_regex 'check_part\(\)\n']; # beginning of validation
+    part_regex = [part_regex 'check_part\s*\(\s*\)\s*\n']; # beginning of validation
     part_regex = [part_regex '(?<validation>.*?)']; # validation
     part_regex = [part_regex '(?=\n(# )?# =+@)']; # beginning of next part        
     [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');

--- a/web/problems/templates/octave/utils.m
+++ b/web/problems/templates/octave/utils.m
@@ -1,25 +1,52 @@
 function parts = extract_parts(src)
-    part_regex = '# =+@(?<part>\d+)=\n';  # beginning of header
-    part_regex = [part_regex '(?<description>(#( [^\n]*)?\n)+)']; # description
-    part_regex = [part_regex '# =+\n'];           # end of header
-    part_regex = [part_regex '(?<solution>.*?)']; # solution
-    part_regex = [part_regex 'check_part\s*\(\s*\)\s*\n']; # beginning of validation
-    part_regex = [part_regex '(?<validation>.*?)']; # validation
-    part_regex = [part_regex '(?=\n(# )?# =+@)']; # beginning of next part        
+    part_regex = '# =+@(?<part>\d+)=\s*\n';          # beginning of header
+    part_regex = [part_regex '(?<description>(\s*#( [^\n]*)?\n)+?)']; # description
+    part_regex = [part_regex '(\s*# ---+\s*\n'];     # optional beginning of template
+    part_regex = [part_regex '(?<template>(\s*#( [^\n]*)?\n)*))?']; # solution template
+    part_regex = [part_regex '\s*# =+\s*?\n'];       # end of header
+    part_regex = [part_regex '(?<solution>.*?)'];    # solution
+    part_regex = [part_regex '\s*check_part\s*\(\s*\)\s*;?\s*\n']; # beginning of validation
+    part_regex = [part_regex '(?<validation>.*?)'];  # validation
+    part_regex = [part_regex '(?=\n\s*(# )?# =+@)']; # beginning of next part
     [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');
     if iscell(nm.part)
       for i=1:length(nm.part)
-        parts{end+1} =  struct("part",nm.part(i),
+        parts{end+1} =  struct("part", nm.part(i),
           "solution", strtrim(nm.solution(i)),
           "validation", strtrim(nm.validation(i)),
-          "description", regexprep(strtrim(nm.description(i)),"^#","",'lineanchors')
+          "description", regexprep(strtrim(nm.description(i)),'^\s*# ?',"",'lineanchors'),
+          "template", regexprep(regexprep(strtrim(nm.template(i)), '^\s*# -+\n', ""), '^\s*# ?',"",'lineanchors')
           );
       end
-    else      
-      parts{1} = struct("part",nm.part,
-      "solution",strtrim(nm.solution),
-      "validation",strtrim(nm.validation),
-      "description", regexprep(strtrim(nm.description),"^# ","",'lineanchors')
+    else
+      parts{1} = struct("part", nm.part,
+      "solution", strtrim(nm.solution),
+      "validation", strtrim(nm.validation),
+      "description", regexprep(strtrim(nm.description),'^\s*# ?',"",'lineanchors'),
+      "template", regexprep(regexprep(strtrim(nm.template), '^\s*# -+\n', ""), '^\s*# ?',"",'lineanchors')
+      );
+    end
+    # The last solution extends all the way to the validation code,
+    # so we strip any trailing whitespace from it.
+endfunction
+
+
+function parts = extract_solutions(src)
+    part_regex = '# =+@(?<part>\d+)=\s*\n';          # beginning of header
+    part_regex = [part_regex '(\s*#( [^\n]*)?\n)+?']; # description
+    part_regex = [part_regex '\s*# =+\s*?\n'];       # end of header
+    part_regex = [part_regex '(?<solution>.*?)'];    # solution
+    part_regex = [part_regex '(?=\n\s*(# )?# =+@)']; # beginning of next part
+    [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');
+    if iscell(nm.part)
+      for i=1:length(nm.part)
+        parts{end+1} =  struct("part", nm.part(i),
+          "solution", strtrim(nm.solution(i))
+          );
+      end
+    else
+      parts{1} = struct("part", nm.part,
+      "solution", strtrim(nm.solution)
       );
     end
     # The last solution extends all the way to the validation code,

--- a/web/problems/templates/python/attempt.py
+++ b/web/problems/templates/python/attempt.py
@@ -173,11 +173,11 @@ def _validate_current_file():
         with open(filename, encoding='utf-8') as f:
             source = f.read()
         part_regex = re.compile(
-            r'# =+@(?P<part>\d+)=\n'  # beginning of header
-            r'(#( [^\n]*)?\n)+'       # description
-            r'# =+\n'                 # end of header
-            r'(?P<solution>.*?)'      # solution
-            r'(?=\n# =+@)',           # beginning of next part
+            r'# =+@(?P<part>\d+)=\s*\n' # beginning of header
+            r'(\s*#( [^\n]*)?\n)+?'     # description
+            r'\s*# =+\s*?\n'            # end of header
+            r'(?P<solution>.*?)'        # solution
+            r'(?=\n\s*# =+@)',          # beginning of next part
             flags=re.DOTALL | re.MULTILINE
         )
         parts = [{

--- a/web/problems/templates/python/edit.py
+++ b/web/problems/templates/python/edit.py
@@ -75,7 +75,7 @@ def extract_problem(filename):
         r'(?P<template>(#( [^\n]*)?\n)*))?'    # solution template
         r'# ===+\n'                            # end of part header
         r'(?P<solution>.*?)'                   # solution
-        r'^Check\.part\(\)\n'                  # beginning of validation
+        r'^Check\s*\.\s*part\s*\(\s*\)\s*\n'   # beginning of validation
         r'(?P<validation>.*?)'                 # validation
         r'(?=\n(# )?# =+@)',                   # beginning of next part
         flags=re.DOTALL | re.MULTILINE

--- a/web/problems/templates/python/edit.py
+++ b/web/problems/templates/python/edit.py
@@ -64,20 +64,20 @@ def extract_problem(filename):
             return ''
         else:
             lines = description.strip().splitlines()
-            return "\n".join(line[2:] for line in lines)
+            return "\n".join(line[line.index('#')+2:] for line in lines)
 
     with open(filename, encoding='utf-8') as f:
         source = f.read()
     part_regex = re.compile(
-        r'# ===+@(?P<part>\d+)=\n'             # beginning of part header
-        r'(?P<description>(#( [^\n]*)?\n)+?)'  # description
-        r'(# ---+\n'                           # optional beginning of template
-        r'(?P<template>(#( [^\n]*)?\n)*))?'    # solution template
-        r'# ===+\n'                            # end of part header
-        r'(?P<solution>.*?)'                   # solution
-        r'^Check\s*\.\s*part\s*\(\s*\)\s*\n'   # beginning of validation
-        r'(?P<validation>.*?)'                 # validation
-        r'(?=\n(# )?# =+@)',                   # beginning of next part
+        r'# ===+@(?P<part>\d+)=\s*\n'             # beginning of part header
+        r'(?P<description>(\s*#( [^\n]*)?\n)+?)'  # description
+        r'(\s*# ---+\s*\n'                        # optional beginning of template
+        r'(?P<template>(\s*#( [^\n]*)?\n)*))?'    # solution template
+        r'\s*# ===+\s*?\n'                        # end of part header
+        r'(?P<solution>.*?)'                      # solution
+        r'^Check\s*\.\s*part\s*\(\s*\)\s*?(?=\n)' # beginning of validation
+        r'(?P<validation>.*?)'                    # validation
+        r'(?=\n\s*(# )?# =+@)',                   # beginning of next part
         flags=re.DOTALL | re.MULTILINE
     )
     parts = [{
@@ -89,10 +89,10 @@ def extract_problem(filename):
         'problem': {{ problem.id }}
     } for match in part_regex.finditer(source)]
     problem_match = re.search(
-        r'^# =+\n'                             # beginning of header
-        r'^# (?P<title>[^\n]*)\n'              # title
-        r'(?P<description>(^#( [^\n]*)?\n)*)'  # description
-        r'(?=(# )?# =+@)',                     # beginning of first part
+        r'^\s*# =+\s*\n'                         # beginning of header
+        r'^\s*# (?P<title>[^\n]*)\n'             # title
+        r'(?P<description>(^\s*#( [^\n]*)?\n)*)' # description
+        r'(?=\s*(# )?# =+@)',                    # beginning of first part
         source, flags=re.DOTALL | re.MULTILINE)
     return {
         'title': problem_match.group('title').strip(),

--- a/web/problems/templates/python/marking.py
+++ b/web/problems/templates/python/marking.py
@@ -172,11 +172,11 @@ def _validate_current_file():
         with open(filename, encoding='utf-8') as f:
             source = f.read()
         part_regex = re.compile(
-            r'# =+@(?P<part>\d+)=\n'  # beginning of header
-            r'(#( [^\n]*)?\n)+'       # description
-            r'# =+\n'                 # end of header
-            r'(?P<solution>.*?)'      # solution
-            r'(?=\n# =+@)',           # beginning of next part
+            r'# =+@(?P<part>\d+)=\s*\n' # beginning of header
+            r'(\s*#( [^\n]*)?\n)+?'     # description
+            r'\s*# =+\s*?\n'            # end of header
+            r'(?P<solution>.*?)'        # solution
+            r'(?=\n\s*# =+@)',          # beginning of next part
             flags=re.DOTALL | re.MULTILINE
         )
         parts = [{

--- a/web/problems/templates/r/attempt.r
+++ b/web/problems/templates/r/attempt.r
@@ -189,19 +189,19 @@
   .source <- paste(readLines(.filename), collapse="\n")
 
   matches <- regex_break(paste(
-      '# =+@(\\d+)=\n',    # beginning of header
-      '(#( [^\n]*)?\n)+',  # description
-      '# =+\n',            # end of header
-      '.*?',               # solution
-      '(?=\n# =+@)',       # beginning of next part
+      '# =+@(\\d+)=\n',        # beginning of header
+      '(\\s*#( [^\n]*)?\n)+?', # description
+      '\\s*# =+\n',            # end of header
+      '.*?',                   # solution
+      '(?=\n\\s*# =+@)',       # beginning of next part
       sep=""
-  ),  c(
-      '# =+@',             # beginning of header
-      '(\\d+)',            # beginning of header (?P<part>)
-      '=\n',               # beginning of header
-      '(#( [^\n]*)?\n)+',  # description
-      '# =+\n',            # end of header
-      '.*?'                # solution
+  ), c(
+      '# =+@',                 # beginning of header
+      '(\\d+)',                # beginning of header (?P<part>)
+      '=\n',                   # beginning of header
+      '(\\s*#( [^\n]*)?\n)+?', # description
+      '\\s*# =+\n',            # end of header
+      '.*?'                    # solution
   ), .source)
 
   check$initialize(

--- a/web/problems/templates/r/edit.r
+++ b/web/problems/templates/r/edit.r
@@ -60,27 +60,26 @@ check$challenge <- function(x, hint = "") {
 
 .extract.problem <- function() {
     matches <- regex_break(paste(
-      '^# ===+@(\\d+)=\n',     # beginning of part header
-      '(^#( [^\n]*)?\n)*',     # description
-      '(# ---+\n',             # optional beginning of template
-      '((#( [^\n]*)?\n)*))?',  # solution template
-      '^# =+\\1@=\n',          # end of part header
-      '.*?',                   # solution
+      '^\\s*# ===+@(\\d+)=\\s*\n', # beginning of part header
+      '(^\\s*#( [^\n]*)?\n)+?',    # description
+      '(\\s*# ---+\\s*\n',         # optional beginning of template
+      '((\\s*#( [^\n]*)?\n)*))?',  # solution template
+      '^\\s*# =+\\1@=\\s*?\n',     # end of part header
+      '.*?',                       # solution
       '^\\s*check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n', # beginning of validation
-      '.*?',                   # validation
-      '^(# )?(?=# =+@)',       # beginning of next part
+      '.*?',                       # validation
+      '^(?=\\s*(# )?# =+@)',       # beginning of next part
       sep=""
     ), c(
-      '^# ===+@',              # beginning of part header
-      '(\\d+)',                # beginning of part header (?P<part>)
-      '=\n',                   # beginning of part header
-      '(^#( [^\n]*)?\n)*?',    # description
-      '(# ---+\n((#( [^\n]*)?\n)*))?',  # solution template
-      '^# =+(\\d+)@=\n',       # end of part header
-      '.*?',                   # solution
-      'check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n',  # beginning of validation
-      '.*?',                   # validation
-      '^(# )?'                 # beginning of next part
+      '^\\s*# ===+@',              # beginning of part header
+      '(\\d+)',                    # beginning of part header (?P<part>)
+      '=\\s*\n',                   # beginning of part header
+      '(^\\s*#( [^\n]*)?\n)+?',    # description
+      '(\\s*# ---+\n(\\s*#( [^\n]*)?\n)*)?', # solution template
+      '^\\s*# =+(\\d+)@=\\s*?\n',  # end of part header
+      '.*?',                       # solution
+      'check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n', # beginning of validation
+      '.*?'                        # validation
     ), .source)
 
     check$initialize(
@@ -88,7 +87,7 @@ check$challenge <- function(x, hint = "") {
           part = as.numeric(match[2]),
           description = super_strip(match[4]),
           solution = strip(match[7]),
-          template = super_strip(gsub("^[^\n]+\n", "", match[5])),
+          template = super_strip(gsub("^\\s*# ---+\n", "", match[5])),
           validation = strip(match[9]),
           problem = {{ problem.id }}
         )
@@ -96,19 +95,17 @@ check$challenge <- function(x, hint = "") {
     )
 
     problem_match <- regex_break(paste(
-      '^# =+\n',           # beginning of header
-      '^# ([^\n]*)\n',     # title
-      '^(#\\s*\n)*',       # empty rows
-      '(^#( [^\n]*)?\n)*', # description
-      '^(# )?(?==+@)',     # beginning of first part
+      '^\\s*# =+\n',           # beginning of header
+      '^\\s*# ([^\n]*)\n',     # title
+      '(^\\s*#( [^\n]*)?\n)*', # description
+      '^(?=\\s*(# )?=+@)',     # beginning of first part
       sep = ""
     ), c(
-      '^# =+\n',           # beginning of header
-      '^# ',               # title
-      '([^\n]*)',          # title (?P<title>)
-      '\n^(#\\s*\n)*',     # title & empty rows
-      '(^#( [^\n]*)?\n)*', # description
-      '^(# )?'             # beginning of first part
+      '^\\s*# =+\n',           # beginning of header
+      '^\\s*# ',               # title
+      '([^\n]*)',              # title (?P<title>)
+      '\n',                    # title
+      '(^\\s*#( [^\n]*)?\n)*'  # description
       ), .source)
 
     if(length(problem_match) == 0)

--- a/web/problems/templates/r/edit.r
+++ b/web/problems/templates/r/edit.r
@@ -66,7 +66,7 @@ check$challenge <- function(x, hint = "") {
       '((#( [^\n]*)?\n)*))?',  # solution template
       '^# =+\\1@=\n',          # end of part header
       '.*?',                   # solution
-      '^check\\$part\\(\\)\n', # beginning of validation
+      '^\\s*check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n', # beginning of validation
       '.*?',                   # validation
       '^(# )?(?=# =+@)',       # beginning of next part
       sep=""
@@ -78,7 +78,7 @@ check$challenge <- function(x, hint = "") {
       '(# ---+\n((#( [^\n]*)?\n)*))?',  # solution template
       '^# =+(\\d+)@=\n',       # end of part header
       '.*?',                   # solution
-      'check\\$part\\(\\)\n',  # beginning of validation
+      'check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n',  # beginning of validation
       '.*?',                   # validation
       '^(# )?'                 # beginning of next part
     ), .source)

--- a/web/problems/templates/r/edit.r
+++ b/web/problems/templates/r/edit.r
@@ -11,7 +11,7 @@ eval(parse(text = substr(.source, gregexpr(paste0("# =L=I=B=", "R=A=R=Y=@="), .s
 # {{ part.description|indent:"# "|safe }}{% if part.template %}
 # ------------------------------------------------------------------------
 # {{ part.template|indent:"# "|safe }}{% endif %}
-# ================================================================{{ part.id|stringformat:'06d'}}@=
+# ========================================================================
 {{ part.solution|safe }}
 
 check$part()
@@ -28,7 +28,7 @@ check$part()
 # #     21
 # #     > multiply(6, 7)
 # #     42{% endblocktrans %}
-# # ================================================================000000@=
+# # ========================================================================
 #
 # {% trans "multiply" %} <- function(x, y) x * y
 #
@@ -64,7 +64,7 @@ check$challenge <- function(x, hint = "") {
       '(^\\s*#( [^\n]*)?\n)+?',    # description
       '(\\s*# ---+\\s*\n',         # optional beginning of template
       '((\\s*#( [^\n]*)?\n)*))?',  # solution template
-      '^\\s*# =+\\1@=\\s*?\n',     # end of part header
+      '^\\s*# ===+\\s*?\n',        # end of part header
       '.*?',                       # solution
       '^\\s*check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n', # beginning of validation
       '.*?',                       # validation
@@ -76,7 +76,7 @@ check$challenge <- function(x, hint = "") {
       '=\\s*\n',                   # beginning of part header
       '(^\\s*#( [^\n]*)?\n)+?',    # description
       '(\\s*# ---+\n(\\s*#( [^\n]*)?\n)*)?', # solution template
-      '^\\s*# =+(\\d+)@=\\s*?\n',  # end of part header
+      '^\\s*# ===+\\s*?\n',        # end of part header
       '.*?',                       # solution
       'check\\s*\\$\\s*part\\s*\\(\\s*\\)\\s*\n', # beginning of validation
       '.*?'                        # validation

--- a/web/problems/templates/r/library.r
+++ b/web/problems/templates/r/library.r
@@ -42,7 +42,7 @@ strip <- function(str) gsub("^\\s+|\\s+$", "", str)
 rstrip <- function(str) gsub("\\s+$", "", str)
 
 super_strip <- function(str) {
-    str <- gsub("(^|\n)# ?", "\n", str)
+    str <- gsub("(^|\n)\\s*# ?", "\n", str)
     gsub("\\A\\s+|\\s+\\Z", "", str, perl=TRUE)
 }
 


### PR DESCRIPTION
Zadnjič sva z @anamariostarijas ugotovila, da Tomo ne prebavlja nalog z nepotrebnimi, a še vedno sintaktično pravilnimi presledki na začetkih vrstic (ali tudi drugod v vrstici s `Check.part`). Tako sem spremenil regularne izraze, da dovolijo prazen prostor pred prvim `#` v vrstici (pa tudi prazne vrstice vmes), in pa sintaktično pravilne presledke v vrstici s `Check.part`.

@mrcinv, mimogrede sem še malo posodobil template za Octave - zdaj deluje oddajanje, pa v template za validacijo sem dodal podpičja na koncu, da se rezultati ne izpisujejo v konzolo. Se ti zdi v redu tako?