### PR TITLE
check_equal za octave preverja tudi dimenzije

### DIFF
--- a/web/problems/templates/octave/attempt.m
+++ b/web/problems/templates/octave/attempt.m
@@ -205,7 +205,7 @@ function validation = validate_current_file(src)
 
   {% for part, _, token in parts %}
       if check_part()
-        check.current_part.token = '{{ token }}'
+        check.current_part.token = '{{ token }}';
         try
               {{ part.validation|default:"0;"|indent:"  "|safe }}
           catch err

--- a/web/problems/templates/octave/check_functions.m
+++ b/web/problems/templates/octave/check_functions.m
@@ -36,7 +36,7 @@ function res = check_equal(koda, rezultat)
   global check;
   res = 0;
   actual_result = eval(koda);
-  if norm(actual_result - rezultat) > 1e-6
+  if any(size(actual_result) != size(rezultat)) || (norm(actual_result - rezultat) > 1e-6)
     check_error(["Izraz ", koda, " vrne ", mat2str(actual_result), " namesto ", mat2str(rezultat)]);
     res = 1;
   end


### PR DESCRIPTION
Popravek za #169. check_equal preverja tudi dimenzije rešitve in javi napako, če se ne ujemajo  s pravilno rešitvijo.