### PR TITLE
Add default value for visible_input

### DIFF
--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -139,7 +139,7 @@ class Check:
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
         try:
-            def visible_input(prompt):
+            def visible_input(prompt=''):
                 inp = input(prompt)
                 print(inp)
                 return inp


### PR DESCRIPTION
`input` se da uporabljat tudi brez parametra - kot je @Kriznar4 opazil, se pojavi problem, če se `input` tako uporabi znotraj `with Check.output()`. Tale popravek odpravi to težavo.

Zanimivo sicer, da docstring za `input` pravi, da je privzeta vrednost parametra `None`, ampak `input(None)` dejansko izpiše `None`...