### PR TITLE
Fix instance where a vector might be used in an if clause

### DIFF
--- a/web/problems/templates/r/library.r
+++ b/web/problems/templates/r/library.r
@@ -17,7 +17,7 @@ if (.error) {
 regex_break <- function(whole_regex, regexes, source) {
     whole_matches <- gregexpr(paste("(?sm)", whole_regex, sep=""), source, perl=TRUE)[[1]]
     n <- length(regexes)
-    if (whole_matches > 0) {
+    if (whole_matches[1] > 0) {
       whole_matches <- mapply(
           function(start, end) substr(source, start, end),
           whole_matches,


### PR DESCRIPTION
Tale pull request popravi nerodnost, ki se mi je izmuznila v #179 in zaradi česar R pri reševanju meče opozorilo, da ima pogoj pri `if` dolžino, večjo od 1.

/CC @spelapovrzenic