### PR TITLE
Matlab support

### DIFF
--- a/web/problems/templates/octave/check_functions.m
+++ b/web/problems/templates/octave/check_functions.m
@@ -42,6 +42,14 @@ function check_secret(x,hint)
   check.parts{check.part_counter}.secret{end+1} = x;
 end
 
+function res = check_substring(koda, podniz)
+  res = 0;
+  if ~isempty(strfind(koda,podniz))
+    check_error(['Resitev ne sme vsebovati niza ',podniz]);
+    res = 1;
+  end
+end
+
 function check_summarize()
   for i=1:check.part_counter
     if not(check_has_solution(check.parts{i}))

--- a/web/problems/templates/octave/utils.m
+++ b/web/problems/templates/octave/utils.m
@@ -9,18 +9,11 @@ function parts = extract_parts(src)
     part_regex = [part_regex '(?<validation>.*?)'];  % validation
     part_regex = [part_regex '(?=\n\s*(% )?% =+@)']; % beginning of next part
     [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');
-    if iscell(nm.part)
-      for i=1:length(nm.part)
-        parts{end+1} =  struct('part', nm.part(i),'solution', strtrim(nm.solution(i)),...
-          'validation', strtrim(nm.validation(i)),...
-          'description', regexprep(strtrim(nm.description(i)),'^\s*% ?','','lineanchors'),...
-          'template', regexprep(regexprep(strtrim(nm.template(i)), '^\s*% -+\n', ''), '^\s*% ?','','lineanchors'));
-      end
-    else
-      parts{1} = struct('part', nm.part,'solution', strtrim(nm.solution),...
-      'validation', strtrim(nm.validation),...
-      'description', regexprep(strtrim(nm.description),'^\s*% ?','','lineanchors'),...
-      'template', regexprep(regexprep(strtrim(nm.template), '^\s*% -+\n', ''), '^\s*% ?','','lineanchors'));
+    for i=1:length(nm)
+        parts{i} =  struct('part', nm(i).part,'solution', strtrim(nm(i).solution),...
+            'validation', strtrim(nm(i).validation),...
+            'description', regexprep(strtrim(nm(i).description),'^\s*% ?','','lineanchors'),...
+            'template', regexprep(regexprep(strtrim(nm(i).template), '^\s*% -+\n', ''), '^\s*% ?','','lineanchors'));
     end
     % The last solution extends all the way to the validation code,
     % so we strip any trailing whitespace from it.
@@ -34,12 +27,8 @@ function parts = extract_solutions(src)
     part_regex = [part_regex '(?<solution>.*?)'];    % solution
     part_regex = [part_regex '(?=\n\s*(% )?% =+@)']; % beginning of next part
     [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');
-    if iscell(nm.part)
-      for i=1:length(nm.part)
-        parts{end+1} =  struct('part', nm.part(i), 'solution', strtrim(nm.solution(i)));
-      end
-    else
-      parts{1} = struct('part', nm.part, 'solution', strtrim(nm.solution));
+    for i=1:length(nm)
+       parts{i} =  struct('part', nm(i).part, 'solution', strtrim(nm(i).solution));
     end
     % The last solution extends all the way to the validation code,
     % so we strip any trailing whitespace from it.


### PR DESCRIPTION
Bor Plestenjak je našel še nekaj napak in sicer ne delujejo naloge, ki imajo več kot eno podnalogo. 
Dodatno je za pomoč naredil še funkcijo check_substring, s katero lahko preverjaš, če rešitev vsebuje izbrani podniz (npr. 'for', če nočeš imeti zanke for).

Spet spremembe vplivajo le na  matlab/octave. 