### PR TITLE
Better io response

### DIFF
--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -186,16 +186,22 @@ class Check:
         global_env = Check.init_environment(env=env, update_env=update_env)
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
+        too_many_read_requests = False
         try:
             exec(expression, global_env)
+        except EOFError:
+            too_many_read_requests = True
         finally:
             output = sys.stdout.getvalue().rstrip().splitlines()
             sys.stdout = old_stdout
         equal, diff, line_width = Check.difflines(output, content)
-        if equal:
+        if equal and not too_many_read_requests:
             return True
         else:
-            Check.error('Program izpiše{0}  namesto:\n  {1}', (line_width - 13) * ' ', '\n  '.join(diff))
+            if too_many_read_requests:
+                Check.error('Program ima pravilen izpis, a želi od uporabnika vnos, ko ta ni več potreben.')
+            if not equal:
+                Check.error('Program izpiše{0}  namesto:\n  {1}', (line_width - 13) * ' ', '\n  '.join(diff))
             return False
 
     @staticmethod

--- a/web/problems/templates/python/check.py
+++ b/web/problems/templates/python/check.py
@@ -199,7 +199,7 @@ class Check:
             return True
         else:
             if too_many_read_requests:
-                Check.error('Program ima pravilen izpis, a želi od uporabnika vnos, ko ta ni več potreben.')
+                Check.error('Program prevečkrat zahteva uporabnikov vnos.')
             if not equal:
                 Check.error('Program izpiše{0}  namesto:\n  {1}', (line_width - 13) * ' ', '\n  '.join(diff))
             return False


### PR DESCRIPTION
Na vajah UVP/Nizi/Ugibanje smo večkrat naleteli na nepohendlan `EOFError`, ko se je v napačni rešitvi naloge še kar klical `input()`, vhoda pa je že zmanjkalo, zato predlagam  popravek `Check.output`

Za pravilnost rešitve je sedaj potreben pravi izhod in ne preveč branj z vhoda. Pripeta je `ugibanje.py` datoteka, spodaj pa je še odziv nanjo (2. naloga je narobe rešena).

```
> Vnesi celo število: a
Žal "a" ni celo število, poskusi ponovno!
> Vnesi celo število: b
Žal "b" ni celo število, poskusi ponovno!
> Vnesi celo število: 14
> Vnesi celo število: 13
> Vnesi celo število: -7898789
> Vnesi celo število: a
Žal "a" ni celo število, poskusi ponovno!
> Vnesi celo število: b
Žal "b" ni celo število, poskusi ponovno!
> Vnesi celo število: 14
Moje število je večje!
> Vnesi celo število: 30
Moje število je manjše!
> Vnesi celo število: x
Žal "x" ni celo število, poskusi ponovno!
> Vnesi celo število: 20
BRAVO! Res sem si zamislil število 20!
Shranjujem rešitve na strežnik... Rešitve so shranjene.
1. podnaloga ima veljavno rešitev.
2. podnaloga nima veljavne rešitve.
  - Pri vhodu
      a
      b
      14
      30
      x
      20
    so se pojavile naslednje napake:
    - Program prevečkrat zahteva uporabnikov vnos.
  - Pri vhodu
      13
      15
    so se pojavile naslednje napake:
    - Program prevečkrat zahteva uporabnikov vnos.
    - Program izpiše                           namesto:
        > Vnesi celo število: 13               | > Vnesi celo število: 13
        BRAVO! Res sem si zamislil število 13! | BRAVO! Res sem si zamislil število 13!
        15                                     *
  - Pri vhodu
      n
      0
      -7898789
    so se pojavile naslednje napake:
    - Program prevečkrat zahteva uporabnikov vnos.
3. podnaloga ima veljavno rešitev.
``
[ugibanje.zip](https://github.com/ul-fmf/projekt-tomo/files/8178778/ugibanje.zip)
`