### PR TITLE
Popravek za ohranitev whitespace v python template

### DIFF
--- a/web/problems/rest.py
+++ b/web/problems/rest.py
@@ -19,6 +19,7 @@ class PartSerializer(ModelSerializer):
     class Meta:
         model = Part
         exclude = ("_order",)
+        extra_kwargs = {"template": {"trim_whitespace": False}}
 
 
 class ProblemSerializer(ModelSerializer):

--- a/web/problems/templates/python/edit.py
+++ b/web/problems/templates/python/edit.py
@@ -71,7 +71,7 @@ def extract_problem(filename):
             return ''
         else:
             lines = description.strip().splitlines()
-            return "\n".join(line[line.index('#')+2:] for line in lines)
+            return "\n".join(line[line.index('#')+2:] for line in lines) + "\n"
 
     with open(filename, encoding='utf-8') as f:
         source = f.read()

--- a/web/problems/templates/python/edit.py
+++ b/web/problems/templates/python/edit.py
@@ -66,12 +66,13 @@ import urllib.request
 {% include 'python/check.py' %}
 
 def extract_problem(filename):
-    def strip_hashes(description):
+    def strip_hashes(description, add_newline=False):
         if description is None:
             return ''
         else:
             lines = description.strip().splitlines()
-            return "\n".join(line[line.index('#')+2:] for line in lines) + "\n"
+            return "\n".join(line[line.index('#')+2:] for line in lines) \
+                 + ('\n' if add_newline else '')
 
     with open(filename, encoding='utf-8') as f:
         source = f.read()
@@ -91,7 +92,7 @@ def extract_problem(filename):
         'part': int(match.group('part')),
         'description': strip_hashes(match.group('description')),
         'solution': match.group('solution').strip(),
-        'template': strip_hashes(match.group('template')),
+        'template': strip_hashes(match.group('template'), add_newline=True),
         'validation': match.group('validation').strip(),
         'problem': {{ problem.id }}
     } for match in part_regex.finditer(source)]


### PR DESCRIPTION
Vrstice v template predelu podnaloge v datoteki za urejanje, ki vsebujejo le hash, se prevedejo na prazne vrstice v datoteki za reševanje;

```
# -----------
# 
# a = [1, 2, 3]
# 
# 
# ==========
```
postane 
```

a = [1, 2, 3]


```

Zapre #171.