### PR TITLE
Polepšan izpis nalog

### DIFF
--- a/web/templates/courses/problem_set_detail.html
+++ b/web/templates/courses/problem_set_detail.html
@@ -148,7 +148,9 @@
             {% for part in problem.parts.all %}
             <li class="list-group-item" id="{{ part.anchor }}">
               {# Translators: problem set detail #}
+              {% if problem.parts.count > 1 %}
               <h5>{{ forloop.counter }}. {% trans "part" %}</h5>
+              {% endif %}
               <p>{{ part.guarded_description|latex_markdown }}</p>
             </li>
             {% endfor %}

--- a/web/templates/problems/solutions.html
+++ b/web/templates/problems/solutions.html
@@ -49,8 +49,13 @@
                       {% else %}<i class="color1 fa fa-times-circle fa-lg"></i>
                       {% endif %}
                     </div>
+                    {% if is_teacher %}
+                    {# Translators: Title of user solutions column with student name. #}
+                    {% trans 'Solution of' %} {{ student.get_full_name }}
+                    {% else %}
                     {# Translators: Title of user solutions column. #}
                     {% trans 'Your solution' %}
+                    {% endif %}
                   </div>
                   <div class="tomo-solution-code-user">
                     {% if part.attempt %}


### PR DESCRIPTION
Besedilo _1. podnaloga_ (_1. part_) se sedaj ne pokaže, če ima naloga le eno podnalogo.

V pregledu rešitve se učiteljem napiše ime in priimek reševalca, neučiteljem pa še vedno _Your solution_.

Zapre #95.