### PR TITLE
Poravnav puščice pri naprednem (časovnem) pogledu

### DIFF
--- a/web/templates/statistics/user_submission_history.html
+++ b/web/templates/statistics/user_submission_history.html
@@ -26,39 +26,45 @@
 <div class='col-md-6' style="height: 100vh; overflow:auto">
 <br>
 {% for problem, timeline in history.items %}
-    <div class='col-md-5'>
-        {{ problem.title }}
-    </div>
-    <div class='col-md-7'> &nbsp;
-    {% for part in problem.parts.all %}
-        <a href="{% url 'user_problem_solution_through_time' student.pk part.pk %}"> <i class="fa fa-arrow-down"></i> </a>
-    {% endfor %}
-    </div>
-    <br>
-    <div class=row>
-        <div class='col-md-2'>
-        </div>
-        <div class='col-md-10'>
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col" class="tomo-overview-student-remove-border">
+                    {{ problem.title }}
+                </th>
+                {% for part in problem.parts.all %}
+                    <th scope="col" class="tomo-overview-student-thin tomo-overview-student-remove-border">
+                        <a href="{% url 'user_problem_solution_through_time' student.pk part.pk %}"> <i class="fa fa-arrow-down"></i> </a>
+                    </th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
             {% for time, state in timeline %}
-                {{ time }} : 
-                {% for attempt in state %}
-                    {% if attempt != None %}
-                        <a href="{% url 'user_problem_solution_at_time' attempt.pk %}">
-                            {% if attempt.valid %}<i class="color5 fa fa-check-circle fa-lg"></i>
-                            {% elif attempt %}<i class="color3 fa fa-question-circle fa-lg"></i>
-                            {% else %}<i class="color1 fa fa-times-circle fa-lg"></i>
-                            {% endif %} </a>
-                    {% else %}
-                        {% if attempt.valid %}<i class="color5 fa fa-check-circle fa-lg"></i>
-                        {% elif attempt %}<i class="color3 fa fa-question-circle fa-lg"></i>
-                        {% else %}<i class="color1 fa fa-times-circle fa-lg"></i>
-                        {% endif %}
-                    {% endif %}
-                {% endfor %} <br>
+                <tr>
+                    <td class="tomo-overview-student-date">
+                        {{ time }} : 
+                    </td>
+                    {% for attempt in state %}
+                        <td class="tomo-overview-student-thin">
+                            {% if attempt != None %}
+                                <a href="{% url 'user_problem_solution_at_time' attempt.pk %}">
+                                    {% if attempt.valid %}<i class="color5 fa fa-check-circle fa-lg"></i>
+                                    {% elif attempt %}<i class="color3 fa fa-question-circle fa-lg"></i>
+                                    {% else %}<i class="color1 fa fa-times-circle fa-lg"></i>
+                                    {% endif %} </a>
+                            {% else %}
+                                {% if attempt.valid %}<i class="color5 fa fa-check-circle fa-lg"></i>
+                                {% elif attempt %}<i class="color3 fa fa-question-circle fa-lg"></i>
+                                {% else %}<i class="color1 fa fa-times-circle fa-lg"></i>
+                                {% endif %}
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                </tr>
             {% endfor %}
-            <br>
-        </div>
-    </div>
+        </tbody>
+    </table>
 {% endfor %}
 </div>
 {% endblock %} {# content #}

--- a/web/utils/static/css/tomo.css
+++ b/web/utils/static/css/tomo.css
@@ -154,10 +154,14 @@ margin-left: 30px; margin-bottom: 5px;}
 .tomo-overview-student { margin-top: 3em; }
 .tomo-overview-student h3 { font-size: 1.2em; }
 .tomo-overview-student table { font-weight: 300; margin-top: 1em; }
+.tomo-overview-student .table>thead>tr>th { border-left: none; border-right: none; }
 .tomo-overview-student .table>tbody>tr>td { border: none; border-bottom: 1px solid #e7e7e7; }
-.tomo-overview-student .row { border-top: 3px solid #e7e7e7; margin-bottom: 2em; }
 /* .tomo-overview-student .container .row:nth-child(even) { background-color: #eee; }
 .tomo-overview-student .container .row:nth-child(odd) { background-color: #fff; } */
+.tomo-overview-student-remove-border { border-left: none; border-right: none; }
+/* the padding values are overwitten by bootstrap if !important is removed */
+.tomo-overview-student-thin { padding: 2px !important; }
+.tomo-overview-student-date { text-align: right; padding: 2px !important; padding-right: 16px !important; }
 
 .tomo-task-solutions { margin-top: 2em; }
 .tomo-task-solutions .tomo-pre { white-space: pre-wrap; font-family: monospace; background-color: #f5f5f5;
@@ -221,7 +225,7 @@ footer img { max-width: 100%; max-height: 6em; margin-bottom: 20px; }
 .pln {
   color: #22221b;
 }
- 
+
 @media screen {
   /* string content */
   .str {


### PR DESCRIPTION
Closes #236 
Namesto z Bootstrapovimi col in row classami so zdaj rezultati urejeni z `<table>`. Zdaj zgleda takole: 
![tomo_poravnane_puscice](https://user-images.githubusercontent.com/50873076/219871198-3b221d58-80a1-4dd0-871f-0c4e5850e2e1.png)
