### PR TITLE
Datoteke za preverjanje uradnih rešitev

### DIFF
--- a/web/courses/models.py
+++ b/web/courses/models.py
@@ -399,6 +399,11 @@ class ProblemSet(OrderWithRespectToMixin, models.Model):
         archive_name = slugify(self.title)
         return archive_name, files
 
+    def solutions_archive(self, user):
+        files = [problem.solution_file(user) for problem in self.problems.all()]
+        archive_name = "{0}-solution".format(slugify(self.title))
+        return archive_name, files
+
     def edit_archive(self, user):
         files = [problem.edit_file(user) for problem in self.problems.all()]
         archive_name = "{0}-edit".format(slugify(self.title))

--- a/web/courses/models.py
+++ b/web/courses/models.py
@@ -399,8 +399,8 @@ class ProblemSet(OrderWithRespectToMixin, models.Model):
         archive_name = slugify(self.title)
         return archive_name, files
 
-    def solutions_archive(self, user):
-        files = [problem.solution_file(user) for problem in self.problems.all()]
+    def solutions_archive(self):
+        files = [problem.solution_file() for problem in self.problems.all()]
         archive_name = "{0}-solution".format(slugify(self.title))
         return archive_name, files
 

--- a/web/courses/urls.py
+++ b/web/courses/urls.py
@@ -15,6 +15,11 @@ problem_set_urls = [
         name="problem_set_attempt",
     ),
     path(
+        "solution/",
+        views.problem_set_solution,
+        name="problem_set_solution",
+    ),
+    path(
         "static/",
         views.problem_set_static,
         name="problem_set_static",

--- a/web/courses/views.py
+++ b/web/courses/views.py
@@ -97,6 +97,15 @@ def problem_set_edit(request, problem_set_pk):
 
 
 @login_required
+def problem_set_solution(request, problem_set_pk):
+    """Download an archive of solution files for a given problem set."""
+    problem_set = get_object_or_404(ProblemSet, pk=problem_set_pk)
+    verify(request.user.can_edit_problem_set(problem_set))
+    archive_name, files = problem_set.solutions_archive(request.user)
+    return zip_archive(archive_name, files)
+
+
+@login_required
 def problem_set_detail(request, problem_set_pk):
     """Show a list of all problems in a problem set."""
     problem_set = get_object_or_404(ProblemSet, pk=problem_set_pk)

--- a/web/courses/views.py
+++ b/web/courses/views.py
@@ -101,7 +101,7 @@ def problem_set_solution(request, problem_set_pk):
     """Download an archive of solution files for a given problem set."""
     problem_set = get_object_or_404(ProblemSet, pk=problem_set_pk)
     verify(request.user.can_edit_problem_set(problem_set))
-    archive_name, files = problem_set.solutions_archive(request.user)
+    archive_name, files = problem_set.solutions_archive()
     return zip_archive(archive_name, files)
 
 

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -84,12 +84,8 @@ class Problem(OrderWithRespectToMixin, models.Model):
         )
         return filename, contents
 
-    def solution_file(self, user):
-        authentication_token = Token.objects.get(user=user)
-        parts = [
-            (part, part.solution, part.attempt_token(user)) for part in self.parts.all()
-        ]
-        url = settings.SUBMISSION_URL + reverse("attempts-submit")
+    def solution_file(self):
+        parts = [(part, part.solution) for part in self.parts.all()]
         problem_slug = slugify(self.title).replace("-", "_")
         extension = self.EXTENSIONS[self.language]
         filename = "{0}_solution.{1}".format(problem_slug, extension)

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -94,12 +94,10 @@ class Problem(OrderWithRespectToMixin, models.Model):
         extension = self.EXTENSIONS[self.language]
         filename = "{0}_solution.{1}".format(problem_slug, extension)
         contents = render_to_string(
-            "{0}/attempt.{1}".format(self.language, extension),
+            "{0}/solution.{1}".format(self.language, extension),
             {
                 "problem": self,
                 "parts": parts,
-                "submission_url": url,
-                "authentication_token": authentication_token,
             },
         )
         return filename, contents

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -84,6 +84,26 @@ class Problem(OrderWithRespectToMixin, models.Model):
         )
         return filename, contents
 
+    def solution_file(self, user):
+        authentication_token = Token.objects.get(user=user)
+        parts = [
+            (part, part.solution, part.attempt_token(user)) for part in self.parts.all()
+        ]
+        url = settings.SUBMISSION_URL + reverse("attempts-submit")
+        problem_slug = slugify(self.title).replace("-", "_")
+        extension = self.EXTENSIONS[self.language]
+        filename = "{0}_solution.{1}".format(problem_slug, extension)
+        contents = render_to_string(
+            "{0}/attempt.{1}".format(self.language, extension),
+            {
+                "problem": self,
+                "parts": parts,
+                "submission_url": url,
+                "authentication_token": authentication_token,
+            },
+        )
+        return filename, contents
+
     def marking_file(self, user):
         attempts = {attempt.part.id: attempt for attempt in self.user_attempts(user)}
         parts = [(part, attempts.get(part.id)) for part in self.parts.all()]

--- a/web/problems/templates/python/solution.py
+++ b/web/problems/templates/python/solution.py
@@ -169,8 +169,6 @@ import re
 import shutil
 import sys
 import traceback
-import urllib.error
-import urllib.request
 
 {% include 'python/check.py' %}
 

--- a/web/problems/templates/python/solution.py
+++ b/web/problems/templates/python/solution.py
@@ -1,0 +1,213 @@
+{% load i18n %}# =============================================================================
+# {{ problem.title|safe }}{% if problem.description %}
+#
+# {{ problem.guarded_description|indent:"# "|safe }}{% endif %}{% for part, solution_attempt, _ in parts %}
+# =====================================================================@{{ part.id|stringformat:'06d'}}=
+# {{ forloop.counter }}. podnaloga
+# {{ part.guarded_description|indent:"# "|safe }}
+# =============================================================================
+{{ solution_attempt|safe }}{% endfor %}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ============================================================================@
+
+'Če vam Python sporoča, da je v tej vrstici sintaktična napaka,'
+'se napaka v resnici skriva v zadnjih vrsticah vaše kode.'
+
+'Kode od tu naprej NE SPREMINJAJTE!'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+import json
+import os
+import re
+import shutil
+import sys
+import traceback
+import urllib.error
+import urllib.request
+
+{% include 'python/check.py' %}
+
+def _validate_current_file():
+    def extract_parts(filename):
+        with open(filename, encoding='utf-8') as f:
+            source = f.read()
+        part_regex = re.compile(
+            r'# =+@(?P<part>\d+)=\s*\n' # beginning of header
+            r'(\s*#( [^\n]*)?\n)+?'     # description
+            r'\s*# =+\s*?\n'            # end of header
+            r'(?P<solution>.*?)'        # solution
+            r'(?=\n\s*# =+@)',          # beginning of next part
+            flags=re.DOTALL | re.MULTILINE
+        )
+        parts = [{
+            'part': int(match.group('part')),
+            'solution': match.group('solution')
+        } for match in part_regex.finditer(source)]
+        # The last solution extends all the way to the validation code,
+        # so we strip any trailing whitespace from it.
+        parts[-1]['solution'] = parts[-1]['solution'].rstrip()
+        return parts
+
+    filename = os.path.abspath(sys.argv[0])
+    file_parts = extract_parts(filename)
+    Check.initialize(file_parts)
+{% for part, _, token in parts %}
+    if Check.part():
+        Check.current_part['token'] = '{{ token }}'
+        try:
+            {{ part.validation|default:"pass"|indent:"            "|safe }}
+        except:
+            Check.error("Testi sprožijo izjemo\n  {0}",
+                        "\n  ".join(traceback.format_exc().split("\n"))[:-2])
+{% endfor %}
+    Check.summarize()
+
+if __name__ == '__main__':
+    _validate_current_file()

--- a/web/problems/templates/python/solution.py
+++ b/web/problems/templates/python/solution.py
@@ -1,167 +1,14 @@
 {% load i18n %}# =============================================================================
 # {{ problem.title|safe }}{% if problem.description %}
 #
-# {{ problem.guarded_description|indent:"# "|safe }}{% endif %}{% for part, solution_attempt, _ in parts %}
+# {{ problem.description|indent:"# "|safe }}{% endif %}{% for part, solution in parts %}
 # =====================================================================@{{ part.id|stringformat:'06d'}}=
 # {{ forloop.counter }}. podnaloga
-# {{ part.guarded_description|indent:"# "|safe }}
+# {{ part.description|indent:"# "|safe }}
 # =============================================================================
-{{ solution_attempt|safe }}{% endfor %}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+{{ solution|safe }}{% endfor %}
 
 # ============================================================================@
-
-'Če vam Python sporoča, da je v tej vrstici sintaktična napaka,'
-'se napaka v resnici skriva v zadnjih vrsticah vaše kode.'
-
-'Kode od tu naprej NE SPREMINJAJTE!'
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 import json
 import os
@@ -196,9 +43,8 @@ def _validate_current_file():
     filename = os.path.abspath(sys.argv[0])
     file_parts = extract_parts(filename)
     Check.initialize(file_parts)
-{% for part, _, token in parts %}
+{% for part, _ in parts %}
     if Check.part():
-        Check.current_part['token'] = '{{ token }}'
         try:
             {{ part.validation|default:"pass"|indent:"            "|safe }}
         except:

--- a/web/problems/urls.py
+++ b/web/problems/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="problem_attempt_file",
     ),
     path(
+        "<int:problem_pk>/solution/",
+        views.problem_solution_file,
+        name="problem_solution_file",
+    ),
+    path(
         "<int:problem_pk>/edit/",
         views.problem_edit_file,
         name="problem_edit_file",

--- a/web/problems/views.py
+++ b/web/problems/views.py
@@ -22,10 +22,19 @@ def problem_attempt_file(request, problem_pk):
 
 @login_required
 def problem_edit_file(request, problem_pk):
-    """Download an attempt file for a given problem."""
+    """Download an edit file for a given problem."""
     problem = get_object_or_404(Problem, pk=problem_pk)
     verify(request.user.can_edit_problem(problem))
     filename, contents = problem.edit_file(user=request.user)
+    return plain_text(filename, contents, content_type=problem.content_type())
+
+
+@login_required
+def problem_solution_file(request, problem_pk):
+    """Download an attempt file with official solutions for a given problem."""
+    problem = get_object_or_404(Problem, pk=problem_pk)
+    verify(request.user.can_edit_problem(problem))
+    filename, contents = problem.solution_file(user=request.user)
     return plain_text(filename, contents, content_type=problem.content_type())
 
 

--- a/web/problems/views.py
+++ b/web/problems/views.py
@@ -34,7 +34,7 @@ def problem_solution_file(request, problem_pk):
     """Download an attempt file with official solutions for a given problem."""
     problem = get_object_or_404(Problem, pk=problem_pk)
     verify(request.user.can_edit_problem(problem))
-    filename, contents = problem.solution_file(user=request.user)
+    filename, contents = problem.solution_file()
     return plain_text(filename, contents, content_type=problem.content_type())
 
 

--- a/web/templates/courses/problem_set_detail.html
+++ b/web/templates/courses/problem_set_detail.html
@@ -28,6 +28,10 @@
                 {# Translators: Datoteke za učence #}
                 {% trans "Student files" %}
             </a></li>
+            <li><a href="{% url 'problem_set_solution' problem_set.pk %}">
+                {# Translators: Datoteke z uradnimi rešitvami #}
+                {% trans "Solution files" %}
+            </a></li>
             <li><a href="{% url 'problem_set_edit' problem_set.pk %}">
                 {# Translators: Datoteke za učitelje #}
                 {% trans "Teacher files" %}
@@ -85,6 +89,10 @@
                         <li><a href="{% url 'problem_attempt_file' problem.id %}">
                             {# Translators: Datoteka za reševanje #}
                             {% trans "File for solving" %}
+                        </a></li>
+                        <li><a href="{% url 'problem_solution_file' problem.id %}">
+                            {# Translators: Datoteka z uradnimi rešitvami #}
+                            {% trans "Solution file" %}
                         </a></li>
                         <li><a href="{% url 'problem_edit_file' problem.id %}">
                             {# Translators: Datoteka za urejanje #}


### PR DESCRIPTION
Dodana je možnost naložiti datoteke za reševanje, ki imajo izpolnjene uradne rešitve, kot je predlagano v #155.
Te datoteke rešitev ne pošiljajo na strežnik, temveč jih le pregledajo.

Trenutno so podprte le naloge v pythonu.