### PR TITLE
Nov način izračuna izidov

### DIFF
--- a/web/attempts/outcome.py
+++ b/web/attempts/outcome.py
@@ -55,6 +55,12 @@ class Outcome:
         empty = f'{self.empty} { _("empty") }'
         return f"{valid} / {invalid} / {empty}"
 
+    def percentage_summary(self):
+        valid = f'{self.valid_percentage}% { _("valid") }'
+        invalid = f'{self.invalid_percentage}% { _("invalid") }'
+        empty = f'{self.empty_percentage}% { _("empty") }'
+        return f"{valid} / {invalid} / {empty}"
+
     @classmethod
     def group_dict(cls, parts, users, parts_group_by, users_group_by):
         part_group_sizes = _group_sizes(parts, *parts_group_by)

--- a/web/attempts/outcome.py
+++ b/web/attempts/outcome.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from django.db.models import Count
+from django.utils.translation import gettext_lazy as _
+
+from .models import Attempt
+
+
+def _group_sizes(queryset, *group_by):
+    if group_by:
+        return {
+            tuple(group): count
+            for *group, count in queryset.values_list(*group_by).annotate(Count("id"))
+        }
+    else:
+        return {(): queryset.count()}
+
+
+@dataclass
+class Outcome:
+    valid: int = 0
+    invalid: int = 0
+    total: int = 0
+
+    def __add__(self, other):
+        return Outcome(
+            self.valid + other.valid,
+            self.invalid + other.invalid,
+            self.total + other.total,
+        )
+
+    @property
+    def empty(self):
+        return self.total - self.valid - self.invalid
+
+    @property
+    def valid_percentage(self):
+        return int(100 * self.valid / self.total)
+
+    @property
+    def invalid_percentage(self):
+        return int(100 * self.invalid / self.total)
+
+    @property
+    def empty_percentage(self):
+        return 100 - self.valid_percentage - self.invalid_percentage
+
+    @property
+    def grade(self):
+        return min(5, int(5 * self.valid / self.total) + 1)
+
+    def summary(self):
+        valid = f'{self.valid} { _("valid") }'
+        invalid = f'{self.invalid} { _("invalid") }'
+        empty = f'{self.empty} { _("empty") }'
+        return f"{valid} / {invalid} / {empty}"
+
+    @classmethod
+    def group_dict(cls, parts, users, parts_group_by, users_group_by):
+        part_group_sizes = _group_sizes(parts, *parts_group_by)
+        user_group_sizes = _group_sizes(users, *users_group_by)
+        outcomes = {}
+        for part_group, part_group_size in part_group_sizes.items():
+            for user_group, user_group_size in user_group_sizes.items():
+                outcomes[part_group + user_group] = cls(
+                    total=part_group_size * user_group_size
+                )
+        attempts = Attempt.objects.filter(part__in=parts, user__in=users).distinct()
+        group_by = [f"part__{g}" for g in parts_group_by] + [
+            f"user__{g}" for g in users_group_by
+        ]
+        for (*group, valid), count in _group_sizes(
+            attempts, *group_by, "valid"
+        ).items():
+            outcomes[tuple(group)] += cls(valid=count) if valid else cls(invalid=count)
+        return outcomes

--- a/web/courses/models.py
+++ b/web/courses/models.py
@@ -376,10 +376,7 @@ class ProblemSet(OrderWithRespectToMixin, models.Model):
         files.append((spreadsheet_filename, spreadsheet_contents))
         return archive_name, files
 
-    def student_statistics(self):
-        students = self.course.observed_students()
-        parts = Part.objects.filter(problem__problem_set=self)
-        outcomes = Outcome.group_dict(parts, students, ("id",), ())
+    def outcomes_statistics(self, outcomes):
         statistics = []
         for problem in self.problems.all():
             parts = []
@@ -401,6 +398,18 @@ class ProblemSet(OrderWithRespectToMixin, models.Model):
                 }
             )
         return statistics
+
+    def single_student_statistics(self, student):
+        students = User.objects.filter(id=student.id)
+        parts = Part.objects.filter(problem__problem_set=self, problem__visible=True)
+        outcomes = Outcome.group_dict(parts, students, ("id",), ())
+        return self.outcomes_statistics(outcomes)
+
+    def all_students_statistics(self):
+        students = self.course.observed_students()
+        parts = Part.objects.filter(problem__problem_set=self)
+        outcomes = Outcome.group_dict(parts, students, ("id",), ())
+        return self.outcomes_statistics(outcomes)
 
     def toggle_visible(self):
         self.visible = not self.visible

--- a/web/courses/views.py
+++ b/web/courses/views.py
@@ -100,12 +100,12 @@ def problem_set_detail(request, problem_set_pk):
     verify(request.user.can_view_problem_set(problem_set))
 
     user_attempts = request.user.attempts.filter(
-        part__problem__problem_set__id=problem_set_pk
+        part__problem__problem_set=problem_set, part__problem__visible=True
     )
-    student_statistics = problem_set.student_statistics()
-    if not request.user.is_teacher(problem_set.course):
-        user_attempts = user_attempts.filter(part__problem__visible=True)
-        student_statistics = list(filter(lambda p: p["visible"], student_statistics))
+    if request.user.is_teacher(problem_set.course):
+        student_statistics = problem_set.all_students_statistics()
+    else:
+        student_statistics = problem_set.single_student_statistics(request.user)
     valid_parts_ids = user_attempts.filter(valid=True).values_list("part_id", flat=True)
     invalid_parts_ids = user_attempts.filter(valid=False).values_list(
         "part_id", flat=True

--- a/web/courses/views.py
+++ b/web/courses/views.py
@@ -130,7 +130,7 @@ def course_detail(request, course_pk):
     course = get_object_or_404(Course, pk=course_pk)
     verify(request.user.can_view_course(course))
     if request.user.can_edit_course(course):
-        students = course.student_success()
+        students = course.student_outcome()
     else:
         students = []
 

--- a/web/courses/views.py
+++ b/web/courses/views.py
@@ -116,6 +116,7 @@ def problem_set_detail(request, problem_set_pk):
         "courses/problem_set_detail.html",
         {
             "problem_set": problem_set,
+            "problems": problem_set.problems.prefetch_related("parts"),
             "valid_parts_ids": valid_parts_ids,
             "invalid_parts_ids": invalid_parts_ids,
             "show_teacher_forms": request.user.can_edit_problem_set(problem_set),
@@ -347,7 +348,6 @@ def course_groups(request, course_pk):
         {
             "course": course,
             "show_teacher_forms": request.user.can_create_course_groups(course),
-            # 'success' : course.student_success_by_problemset_grouped_by_groups()
         },
     )
 

--- a/web/templates/courses/_problem_set.html
+++ b/web/templates/courses/_problem_set.html
@@ -4,20 +4,20 @@
   {% if course.is_taught %}
   {% spaceless %}
   <div data-toggle="tooltip"
-       title="{{ problem_set.valid }}% {% trans "valid" %} / {{ problem_set.invalid }}% {% trans "invalid" %} / {{ problem_set.empty }}% {% trans "empty" %} ">
-  {% if problem_set.valid %}
-  <hr class="indicator background5" width="{{ problem_set.valid }}%">
+       title="{{ problem_set.outcome.percentage_summary }} ">
+  {% if problem_set.outcome.valid_percentage %}
+  <hr class="indicator background5" width="{{ problem_set.outcome.valid_percentage }}%">
   {% endif %}
-  {% if problem_set.invalid %}
-  <hr class="indicator background3" width="{{ problem_set.invalid }}%">
+  {% if problem_set.outcome.invalid_percentage %}
+  <hr class="indicator background3" width="{{ problem_set.outcome.invalid_percentage }}%">
   {% endif %}
-  {% if problem_set.empty %}
-  <hr class="indicator background1" width="{{ problem_set.empty }}%">
+  {% if problem_set.outcome.empty_percentage %}
+  <hr class="indicator background1" width="{{ problem_set.outcome.empty_percentage }}%">
   {% endif %}
   </div>
   {% endspaceless %}
   {% else %}
-  <hr class="indicator background{{problem_set.grade}}" width="{{ problem_set.percentage }}%">
+  <hr class="indicator background{{problem_set.outcome.grade}}" width="{{ problem_set.outcome.valid_percentage }}%">
   {% endif %}
 
   <div class="media">
@@ -103,14 +103,14 @@
 
     {% if course.is_taught %}
     <div class="media-left">
-      <p class="success text-danger color{{ problem_set.grade }}">
-        {{ problem_set.valid }}<small>%</small>
+      <p class="success text-danger color{{ problem_set.outcome.grade }}">
+        {{ problem_set.outcome.valid_percentage }}<small>%</small>
       </p>
     </div>
     {% else %}
     <div class="media-left">
-      <p class="success text-danger color{{ problem_set.grade }}">
-        {{ problem_set.percentage }}<small>%</small>
+      <p class="success text-danger color{{ problem_set.outcome.grade }}">
+        {{ problem_set.outcome.valid_percentage }}<small>%</small>
       </p>
     </div>
     {% endif %}

--- a/web/templates/courses/_problem_set.html
+++ b/web/templates/courses/_problem_set.html
@@ -101,19 +101,11 @@
     </div>
     {% endif %}
 
-    {% if course.is_taught %}
     <div class="media-left">
       <p class="success text-danger color{{ problem_set.outcome.grade }}">
         {{ problem_set.outcome.valid_percentage }}<small>%</small>
       </p>
     </div>
-    {% else %}
-    <div class="media-left">
-      <p class="success text-danger color{{ problem_set.outcome.grade }}">
-        {{ problem_set.outcome.valid_percentage }}<small>%</small>
-      </p>
-    </div>
-    {% endif %}
 
     <div class="media-body media-middle">
       <div class="row">

--- a/web/templates/courses/course_detail.html
+++ b/web/templates/courses/course_detail.html
@@ -126,9 +126,9 @@
       $(function() {
         {% for student in students %}
         $("#student{{student.pk}}").drawPieChart([
-          { value : {{ student.empty }},  color: "#A92D2D" },
-          { value:  {{ student.invalid }},   color: "#D7A02C" },
-          { value : {{ student.valid }},   color: "#878F28" }
+          { value: {{ student.outcome.empty }}, color: "#A92D2D" },
+          { value: {{ student.outcome.invalid }}, color: "#D7A02C" },
+          { value: {{ student.outcome.valid }}, color: "#878F28" }
         ]);
         {% endfor %}
       });

--- a/web/templates/courses/course_progress.html
+++ b/web/templates/courses/course_progress.html
@@ -14,27 +14,27 @@
 <div class="content-section-a tomo-overview-student">
   <div class="container">
     <h2>{{ observed_user.title }}</h2>
-      {% for problem_set, problem_set_attempts, ps_valid, ps_invalid, ps_empty in course_attempts %}
+      {% for problem_set in course_attempts %}
       <div class="row">
       <div class="col-md-4">
         <h3><a href="{{ problem_set.get_absolute_url }}"
                    data-toggle="tooltip"
-                   title="{{ ps_valid }} {% trans "valid" %} / {{ ps_invalid }} {% trans "invalid" %} / {{ ps_empty }} {% trans "empty" %} ">
+                   title="{{ problem_set.outcome.summary }} ">
 {{ problem_set.title }}</a></h3>
       </div>
       <div class="col-md-8">
         <table class="table table-condensed">
           <tbody>
-            {% for problem, problem_attempts, valid, invalid, empty in problem_set_attempts %}
+            {% for problem in problem_set.attempts %}
             <tr>
               <td>
                 <a href="{{ problem.get_absolute_url }}"
                    data-toggle="tooltip"
-                   title="{{ valid }} {% trans "valid" %} / {{ invalid }} {% trans "invalid" %} / {{ empty }} {% trans "empty" %} ">
+                   title="{{ problem.outcome.summary }} ">
               {{ problem.title }}</a>
               </td>
               <td width='60%'>
-                {% for attempt in problem_attempts %}
+                {% for attempt in problem.attempts %}
                 <a href="{% url 'problem_solution' problem.pk observed_user.pk %}" class="solution-circle">
                   {% if attempt.valid %}<i class="color5 fa fa-check-circle fa-lg"></i>
                   {% elif attempt %}<i class="color3 fa fa-question-circle fa-lg"></i>

--- a/web/templates/courses/problem_set_detail.html
+++ b/web/templates/courses/problem_set_detail.html
@@ -83,7 +83,7 @@
           <hr>
         {% endif %}
 
-        {% for problem in problem_set.problems.all %}
+        {% for problem in problems %}
         {% if problem.visible or show_teacher_forms %}
         <div id="{{ problem.anchor }}" class="panel panel-default">
           <div id="{{ problem.anchor }}" class="panel-heading">
@@ -195,7 +195,8 @@
           {% endif %}
 
           <ul class="list-group tomo-subtasks">
-            {% for part in problem.parts.all %}
+            {% with problem.parts.all as parts %}
+            {% for part in parts %}
               {% if part.pk in valid_parts_ids %}
               <li class="list-group-item tomo-subtask-valid" id="{{ part.anchor }}">
               {% elif part.pk in invalid_parts_ids %}
@@ -204,12 +205,13 @@
               <li class="list-group-item tomo-subtask-empty" id="{{ part.anchor }}">
               {% endif %}
               {# Translators: problem set detail #}
-              {% if problem.parts.count > 1 %}
+              {% if parts|length > 1 %}
               <h5>{{ forloop.counter }}. {% trans "part" %}</h5>
               {% endif %}
               <p>{{ part.guarded_description|latex_markdown }}</p>
             </li>
             {% endfor %}
+            {% endwith %}
           </ul>
         </div>
 	    {% endif %}
@@ -263,23 +265,11 @@
 $(function() {
   {% for problem in student_statistics %}
   {% for part in problem.parts %}
-  {% if show_teacher_forms %}
   $("#pieChart-{{ problem.pk }}-{{ part.pk }}").drawPieChart([
     {value: {{ part.outcome.valid }}, color: "#878F28"},
     {value: {{ part.outcome.invalid }}, color: "#D7A02C"},
     {value: {{ part.outcome.empty }}, color: "#A92D2D"},
   ]);
-  {% else %}
-  $("#pieChart-{{ problem.pk }}-{{ part.pk }}").drawPieChart([
-    {% if part.pk in valid_parts_ids %}
-    {value: 1, color: "#878F28"},
-    {% elif part.pk in invalid_parts_ids %}
-    {value: 1, color: "#D7A02C"},
-    {% else %}
-    {value: 1, color: "#A92D2D"},
-    {% endif %}
-  ]);
-  {% endif %}
   {% endfor %}
   {% endfor %}
 });

--- a/web/templates/courses/problem_set_detail.html
+++ b/web/templates/courses/problem_set_detail.html
@@ -238,7 +238,7 @@
               {% if show_teacher_forms %}
                 <a href="{% url 'problem_set_progress' problem_set.pk %}#{{problem.anchor}}"
                    data-toggle="tooltip"
-                   title="{{ part.valid }} {% trans "valid" %} / {{ part.invalid }} {% trans "invalid" %} / {{ part.empty }} {% trans "empty" %} ">
+                   title="{{ part.outcome.summary }} ">
               {% else %}
                 <a href="#{{part.anchor}}">
               {% endif %}
@@ -265,9 +265,9 @@ $(function() {
   {% for part in problem.parts %}
   {% if show_teacher_forms %}
   $("#pieChart-{{ problem.pk }}-{{ part.pk }}").drawPieChart([
-    {value: {{ part.valid }}, color: "#878F28"},
-    {value: {{ part.invalid }}, color: "#D7A02C"},
-    {value: {{ part.empty }}, color: "#A92D2D"},
+    {value: {{ part.outcome.valid }}, color: "#878F28"},
+    {value: {{ part.outcome.invalid }}, color: "#D7A02C"},
+    {value: {{ part.outcome.empty }}, color: "#A92D2D"},
   ]);
   {% else %}
   $("#pieChart-{{ problem.pk }}-{{ part.pk }}").drawPieChart([

--- a/web/templates/courses/problem_set_progress.html
+++ b/web/templates/courses/problem_set_progress.html
@@ -34,7 +34,7 @@
                 <td>
                   <a href="{% url 'course_progress' problem.problem_set.course.pk observed_user.pk %}"
                     data-toggle="tooltip"
-                    title="{{ observed_user.valid }} {% trans "valid" %} / {{ observed_user.invalid }} {% trans "invalid" %} / {{ observed_user.empty }} {% trans "empty" %} ">
+                    title="{{ observed_user.outcome.summary }}">
                     {{ observed_user.get_full_name }}</a>
                 </td>
                 <td width='60%'>

--- a/web/templates/courses/problem_set_progress_groups.html
+++ b/web/templates/courses/problem_set_progress_groups.html
@@ -35,7 +35,7 @@
                       <td>
                         <a href="{% url 'course_progress' problem.problem_set.course.pk observed_user.pk %}"
                           data-toggle="tooltip"
-                          title="{{ observed_user.valid }} {% trans "valid" %} / {{ observed_user.invalid }} {% trans "invalid" %} / {{ observed_user.empty }} {% trans "empty" %} ">
+                          title="{{ observed_user.outcome.summary }} ">
                           {{ observed_user.get_full_name }}</a>
                       </td>
                       <td width='60%'>

--- a/web/users/models.py
+++ b/web/users/models.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.utils.functional import cached_property
 from rest_framework.authtoken.models import Token
 
 
@@ -48,6 +49,7 @@ class User(AbstractUser):
     def is_teacher(self, course):
         return self in course.teachers.all()
 
+    @cached_property
     def is_teacher_anywhere(self):
         return self.taught_courses.exists()
 


### PR DESCRIPTION
Na veliko koncih na strani uporabljamo različne vrste semaforjev, npr.:
- delež veljavnih/neveljavnih/manjkajočih rešitev vseh podnalog vseh učencev pri danem sklopu
- delež veljavnih/neveljavnih/manjkajočih rešitev vseh podnalog v predmetu pri danem učencu
- delež veljavnih/neveljavnih/manjkajočih rešitev vseh učencev pri dani podnalogi
- delež veljavnih rešitev učenca pri vsakem sklopu
- ...
Do sedaj se je vsaka od teh stvari računala na svoj način, zdaj pa se to poenoti z enim razredom `Outcome`. Zraven sem še optimiziral par stvari.
